### PR TITLE
chore: Update release workflow to check main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: ⛔️ Verify tag is on the main branch
         run: |
-          git branch --contains ${{ github.ref_name }} | grep 'origin/main$'
+          git branch -r --contains ${{ github.ref_name }} | grep 'origin/main$'
           echo "✅ Release tag is on the main branch. Proceeding."
 
       - name: Log in to Docker Hub


### PR DESCRIPTION
- Update release workflow to correctly check if the release tag is on the main branch by using the correct git command.