### PR TITLE
feat: Add delete by name prefix endpoint for contacts

### DIFF
--- a/src/main/java/br/com/personal/opencontact/api/contact/ContactController.java
+++ b/src/main/java/br/com/personal/opencontact/api/contact/ContactController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -65,6 +66,13 @@ public class ContactController {
     @DeleteMapping("/contacts/{id}")
     public ResponseEntity<Void> delete(@PathVariable UUID id) {
         contactService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/agendas/{agendaId}/contacts")
+    public ResponseEntity<Void> deleteContactsByNamePrefix(@PathVariable UUID agendaId,
+                                                           @RequestParam String namePrefix) {
+        contactService.deleteContactsByNamePrefix(agendaId, namePrefix);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/br/com/personal/opencontact/api/contact/ContactRepository.java
+++ b/src/main/java/br/com/personal/opencontact/api/contact/ContactRepository.java
@@ -2,7 +2,11 @@ package br.com.personal.opencontact.api.contact;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -36,4 +40,14 @@ public interface ContactRepository extends JpaRepository<Contact, UUID>, JpaSpec
      * @return whether any contact with the given id exists
      */
     boolean existsByAgendaId(UUID agendaId);
+
+    /**
+     * Deletes all contacts with the given {@code agendaId} and whose name starts with the given {@code namePrefix}, ignoring case.
+     *
+     * @param agendaId the id of the agenda
+     * @param namePrefix the prefix of the contact name
+     */
+    @Modifying
+    @Query("DELETE FROM Contact c WHERE c.agenda.id = :agendaId AND lower(c.name) LIKE lower(concat(:namePrefix, '%'))")
+    void deleteByAgendaIdAndNameStartingWithIgnoreCase(@Param("agendaId") UUID agendaId, @Param("namePrefix") String namePrefix);
 }

--- a/src/main/java/br/com/personal/opencontact/api/contact/ContactService.java
+++ b/src/main/java/br/com/personal/opencontact/api/contact/ContactService.java
@@ -2,6 +2,7 @@ package br.com.personal.opencontact.api.contact;
 
 import br.com.personal.opencontact.api.agenda.Agenda;
 import br.com.personal.opencontact.api.agenda.AgendaRepository;
+import br.com.personal.opencontact.api.agenda.AgendaService;
 import br.com.personal.opencontact.api.common.exceptions.PhoneAlreadyExistsException;
 import br.com.personal.opencontact.api.contact.dto.ContactCreateDTO;
 import br.com.personal.opencontact.api.contact.dto.ContactUpdateDTO;
@@ -20,6 +21,7 @@ import java.util.UUID;
 public class ContactService {
 
     private final ContactRepository contactRepository;
+    private final AgendaService agendaService;
     private final AgendaRepository agendaRepository;
 
     @Transactional
@@ -89,5 +91,11 @@ public class ContactService {
 
         Specification<Contact> spec = ContactSpecification.filterBy(agendaId, nameContains, phoneContains);
         return contactRepository.findAll(spec, pageable);
+    }
+
+    @Transactional
+    public void deleteContactsByNamePrefix(UUID agendaId, String namePrefix) {
+        agendaService.findById(agendaId);
+        contactRepository.deleteByAgendaIdAndNameStartingWithIgnoreCase(agendaId, namePrefix);
     }
 }


### PR DESCRIPTION
- Add endpoint to delete contacts by name prefix for a given agenda.
- Add method to delete contacts by agenda ID and name prefix, case‑insensitive.
- Add method to delete contacts by name prefix and inject AgendaService for validation.