### PR TITLE
feat: Add delete by name prefix endpoint for contacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,4 @@ jobs:
           distribution: 'temurin'
 
       - name: Build with Maven and run tests
-        # TODO: Replace with your actual build and test command e.g., './mvnw verify'
-        run: echo "Simulating a successful build and test run..."
+        run: ./mvnw clean install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
+          architecture: 'x64'
 
-      - name: Build with Maven and run tests
-        run: ./mvnw clean install
+      - name: Run the Maven verify phase
+        run: mvn --batch-mode --update-snapshots verify

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Para verificar a saúde da aplicação e de seus componentes (como a conexão co
 
 Apesar de o MVP estar completo, existem várias melhorias que podem ser implementadas para tornar a API ainda mais robusta e pronta para produção:
 
-- [ ] **Testes Automatizados:** Implementar testes unitários (JUnit/Mockito) para a camada de serviço e testes de integração para a camada de controller.
+- [x] **Testes Automatizados:** Implementar testes unitários (JUnit/Mockito) para a camada de serviço e testes de integração para a camada de controller.
 - [ ] **Segurança:** Adicionar autenticação e autorização usando Spring Security e JWT para proteger os endpoints.
 - [ ] **Tratamento de Erros Avançado:** Criar um DTO de erro padrão para todas as respostas de erro da API.
 - [ ] **Atualizações Parciais (PATCH):** Implementar o verbo HTTP `PATCH` para permitir a atualização de campos individuais de um recurso.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,8 @@
-# Define a rede customizada para nossos serviços
 networks:
   opencontact_internal_network:
     name: opencontact_internal_network
     driver: bridge
 
-# Define os volumes persistentes
 volumes:
   postgres_data:
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,13 @@
                 <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
                 <version>2.8.11</version>
             </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.21.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -75,6 +82,24 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -90,6 +115,16 @@
                         </exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.4</version> <configuration>
+                <includes>
+                    <include>**/*Test.java</include>
+                    <include>**/*Tests.java</include>
+                    <include>**/*IT.java</include> </includes>
+            </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/br/com/personal/opencontact/api/contact/Contact.java
+++ b/src/main/java/br/com/personal/opencontact/api/contact/Contact.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -16,6 +17,7 @@ import java.util.UUID;
 @Table(name = "contacts")
 @EntityListeners(AuditingEntityListener.class)
 @Getter
+@Setter
 @NoArgsConstructor
 @EqualsAndHashCode(of = "id")
 public class Contact {

--- a/src/main/java/br/com/personal/opencontact/api/contact/ContactController.java
+++ b/src/main/java/br/com/personal/opencontact/api/contact/ContactController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -65,6 +66,13 @@ public class ContactController {
     @DeleteMapping("/contacts/{id}")
     public ResponseEntity<Void> delete(@PathVariable UUID id) {
         contactService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/agendas/{agendaId}/contacts")
+    public ResponseEntity<Void> deleteContactsByNamePrefix(@PathVariable UUID agendaId,
+                                                           @RequestParam String namePrefix) {
+        contactService.deleteContactsByNamePrefix(agendaId, namePrefix);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/br/com/personal/opencontact/api/contact/ContactRepository.java
+++ b/src/main/java/br/com/personal/opencontact/api/contact/ContactRepository.java
@@ -2,7 +2,11 @@ package br.com.personal.opencontact.api.contact;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -36,4 +40,14 @@ public interface ContactRepository extends JpaRepository<Contact, UUID>, JpaSpec
      * @return whether any contact with the given id exists
      */
     boolean existsByAgendaId(UUID agendaId);
+
+    /**
+     * Deletes all contacts with the given {@code agendaId} and whose name starts with the given {@code namePrefix}, ignoring case.
+     *
+     * @param agendaId the id of the agenda
+     * @param namePrefix the prefix of the contact name
+     */
+    @Modifying
+    @Query("DELETE FROM Contact c WHERE c.agenda.id = :agendaId AND lower(c.name) LIKE lower(concat(:namePrefix, '%'))")
+    void deleteByAgendaIdAndNameStartingWithIgnoreCase(@Param("agendaId") UUID agendaId, @Param("namePrefix") String namePrefix);
 }

--- a/src/main/java/br/com/personal/opencontact/api/contact/ContactService.java
+++ b/src/main/java/br/com/personal/opencontact/api/contact/ContactService.java
@@ -2,6 +2,7 @@ package br.com.personal.opencontact.api.contact;
 
 import br.com.personal.opencontact.api.agenda.Agenda;
 import br.com.personal.opencontact.api.agenda.AgendaRepository;
+import br.com.personal.opencontact.api.agenda.AgendaService;
 import br.com.personal.opencontact.api.common.exceptions.PhoneAlreadyExistsException;
 import br.com.personal.opencontact.api.contact.dto.ContactCreateDTO;
 import br.com.personal.opencontact.api.contact.dto.ContactUpdateDTO;
@@ -20,6 +21,7 @@ import java.util.UUID;
 public class ContactService {
 
     private final ContactRepository contactRepository;
+    private final AgendaService agendaService;
     private final AgendaRepository agendaRepository;
 
     @Transactional
@@ -89,5 +91,11 @@ public class ContactService {
 
         Specification<Contact> spec = ContactSpecification.filterBy(agendaId, nameContains, phoneContains);
         return contactRepository.findAll(spec, pageable);
+    }
+
+    @Transactional
+    public void deleteContactsByNamePrefix(UUID agendaId, String namePrefix) {
+        agendaService.findById(agendaId);
+        contactRepository.deleteByAgendaIdAndNameStartingWithIgnoreCase(agendaId, namePrefix);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 server.servlet.context-path=/api/v1
 
 spring.application.name=open-contact-api
-spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opencontact_db}
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/opencontact}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:seu_usuario_postgres}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:sua_senha_postgres}
 

--- a/src/test/java/br/com/personal/opencontact/api/AbstractIntegrationTest.java
+++ b/src/test/java/br/com/personal/opencontact/api/AbstractIntegrationTest.java
@@ -1,0 +1,15 @@
+package br.com.personal.opencontact.api;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+@ContextConfiguration(initializers = {PostgresContainerInitializer.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+        "spring.liquibase.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+public abstract class AbstractIntegrationTest {
+
+}

--- a/src/test/java/br/com/personal/opencontact/api/OpenContactApiApplicationTests.java
+++ b/src/test/java/br/com/personal/opencontact/api/OpenContactApiApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class OpenContactApiApplicationTests {
+class OpenContactApiApplicationTests extends AbstractIntegrationTest {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/br/com/personal/opencontact/api/PostgresContainerInitializer.java
+++ b/src/test/java/br/com/personal/opencontact/api/PostgresContainerInitializer.java
@@ -1,0 +1,24 @@
+package br.com.personal.opencontact.api;
+
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class PostgresContainerInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    private static final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    static {
+        postgresContainer.start();
+    }
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        TestPropertyValues.of(
+                "spring.datasource.url=" + postgresContainer.getJdbcUrl(),
+                "spring.datasource.username=" + postgresContainer.getUsername(),
+                "spring.datasource.password=" + postgresContainer.getPassword()
+        ).applyTo(applicationContext.getEnvironment());
+    }
+}

--- a/src/test/java/br/com/personal/opencontact/api/agenda/AgendaControllerIT.java
+++ b/src/test/java/br/com/personal/opencontact/api/agenda/AgendaControllerIT.java
@@ -1,0 +1,52 @@
+package br.com.personal.opencontact.api.agenda;
+
+import br.com.personal.opencontact.api.AbstractIntegrationTest;
+import br.com.personal.opencontact.api.agenda.dto.AgendaCreateDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc
+@Transactional
+class AgendaControllerIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AgendaRepository agendaRepository;
+
+    @Test
+    @DisplayName("POST /agendas should create an agenda and return 201 Created")
+    void postAgenda_whenValidInput_shouldReturn201AndCreateAgenda() throws Exception {
+        var createDTO = new AgendaCreateDTO("Familia");
+        String jsonPayload = objectMapper.writeValueAsString(createDTO);
+
+        mockMvc.perform(post("/agendas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isCreated())
+                .andExpect(header().exists("Location"))
+                .andExpect(header().string("Location", matchesPattern("^http://localhost/agendas/[a-f0-9\\-]+$")))
+                .andExpect(jsonPath("$.name").value("Familia"));
+
+        List<Agenda> agendas = agendaRepository.findAll();
+        assertThat(agendas).hasSize(1);
+        assertThat(agendas.getFirst().getName()).isEqualTo("Familia");
+    }
+}

--- a/src/test/java/br/com/personal/opencontact/api/agenda/AgendaServiceTest.java
+++ b/src/test/java/br/com/personal/opencontact/api/agenda/AgendaServiceTest.java
@@ -1,0 +1,181 @@
+package br.com.personal.opencontact.api.agenda;
+
+import br.com.personal.opencontact.api.agenda.dto.AgendaCreateDTO;
+import br.com.personal.opencontact.api.agenda.dto.AgendaUpdateDTO;
+import br.com.personal.opencontact.api.common.exceptions.AgendaNameAlreadyExistsException;
+import br.com.personal.opencontact.api.contact.ContactRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AgendaServiceTest {
+
+    @Mock
+    private AgendaRepository agendaRepository;
+    @Mock
+    private ContactRepository contactRepository;
+    @InjectMocks
+    private AgendaService agendaService;
+
+    @Test
+    @DisplayName("Create should save agenda when name is unique")
+    void create_shouldSaveAgenda_whenNameIsUnique() {
+        var createDTO = new AgendaCreateDTO("Familia");
+        var generatedId = UUID.randomUUID();
+
+        when(agendaRepository.existsByNameIgnoreCase(createDTO.name())).thenReturn(false);
+        when(agendaRepository.save(any(Agenda.class))).thenAnswer(invocation -> {
+            Agenda agendaToSave = invocation.getArgument(0);
+            agendaToSave.setId(generatedId);
+            return agendaToSave;
+        });
+
+        Agenda savedAgenda = agendaService.create(createDTO);
+
+        assertThat(savedAgenda).isNotNull();
+        assertThat(savedAgenda.getId()).isEqualTo(generatedId);
+        assertThat(savedAgenda.getName()).isEqualTo("Familia");
+
+        verify(agendaRepository).existsByNameIgnoreCase("Familia");
+        verify(agendaRepository).save(any(Agenda.class));
+    }
+
+    @Test
+    @DisplayName("create should throw exception when name already exists")
+    void create_shouldThrowException_whenNameAlreadyExists() {
+        var createDTO = new AgendaCreateDTO("Familia");
+        when(agendaRepository.existsByNameIgnoreCase(createDTO.name())).thenReturn(true);
+
+        assertThatThrownBy(() -> agendaService.create(createDTO))
+                .isInstanceOf(AgendaNameAlreadyExistsException.class)
+                .hasMessage("Agenda name 'Familia' already exists.");
+
+        verify(agendaRepository).existsByNameIgnoreCase("Familia");
+        verify(agendaRepository, never()).save(any(Agenda.class));
+    }
+
+    @Test
+    @DisplayName("findById should return agenda when id exists")
+    void findById_shouldReturnAgenda_whenIdExists() {
+        var agendaId = UUID.randomUUID();
+        var existingAgenda = new Agenda();
+        existingAgenda.setId(agendaId);
+        existingAgenda.setName("Trabalho");
+
+        when(agendaRepository.findById(agendaId)).thenReturn(Optional.of(existingAgenda));
+
+        Agenda foundAgenda = agendaService.findById(agendaId);
+
+        assertThat(foundAgenda).isNotNull();
+        assertThat(foundAgenda.getId()).isEqualTo(agendaId);
+        assertThat(foundAgenda.getName()).isEqualTo("Trabalho");
+        verify(agendaRepository).findById(agendaId);
+    }
+
+    @Test
+    @DisplayName("findById should throw exception when id does not exist")
+    void findById_shouldThrowException_whenIdDoesNotExist() {
+        var nonExistentId = UUID.randomUUID();
+        when(agendaRepository.findById(nonExistentId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> agendaService.findById(nonExistentId))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("Agenda not found with id: " + nonExistentId);
+
+        verify(agendaRepository).findById(nonExistentId);
+    }
+
+    @Test
+    @DisplayName("update should change agenda name when successful")
+    void update_shouldChangeAgendaName_whenSuccessful() {
+        var agendaId = UUID.randomUUID();
+        var updateDTO = new AgendaUpdateDTO("Trabalho Novo");
+
+        var originalAgenda = new Agenda("Trabalho");
+        originalAgenda.setId(agendaId);
+
+        when(agendaRepository.findById(agendaId)).thenReturn(Optional.of(originalAgenda));
+        when(agendaRepository.findByNameIgnoreCase("Trabalho Novo")).thenReturn(Optional.empty());
+        when(agendaRepository.save(any(Agenda.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Agenda updatedAgenda = agendaService.update(agendaId, updateDTO);
+
+        assertThat(updatedAgenda).isNotNull();
+        assertThat(updatedAgenda.getId()).isEqualTo(agendaId);
+        assertThat(updatedAgenda.getName()).isEqualTo("Trabalho Novo");
+        verify(agendaRepository).findById(agendaId);
+        verify(agendaRepository).findByNameIgnoreCase("Trabalho Novo");
+        verify(agendaRepository).save(originalAgenda);
+    }
+
+    @Test
+    @DisplayName("update should throw exception when new name already exists in another agenda")
+    void update_shouldThrowException_whenNewNameExistsInAnotherAgenda() {
+        var agendaToUpdateId = UUID.randomUUID();
+        var anotherAgendaId = UUID.randomUUID();
+        var updateDTO = new AgendaUpdateDTO("Amigos");
+
+        var agendaToUpdate = new Agenda("Trabalho");
+        agendaToUpdate.setId(agendaToUpdateId);
+
+        var existingAgendaWithSameName = new Agenda("Amigos");
+        existingAgendaWithSameName.setId(anotherAgendaId);
+
+        when(agendaRepository.findById(agendaToUpdateId)).thenReturn(Optional.of(agendaToUpdate));
+        when(agendaRepository.findByNameIgnoreCase("Amigos")).thenReturn(Optional.of(existingAgendaWithSameName));
+
+        assertThatThrownBy(() -> agendaService.update(agendaToUpdateId, updateDTO))
+                .isInstanceOf(AgendaNameAlreadyExistsException.class)
+                .hasMessage("Agenda name 'Amigos' already exists.");
+
+        verify(agendaRepository).findById(agendaToUpdateId);
+        verify(agendaRepository).findByNameIgnoreCase("Amigos");
+        verify(agendaRepository, never()).save(any(Agenda.class));
+    }
+
+    @Test
+    @DisplayName("delete should remove agenda when it has no associated contacts")
+    void delete_shouldRemoveAgenda_whenItHasNoAssociatedContacts() {
+        var agendaId = UUID.randomUUID();
+
+        when(agendaRepository.existsById(agendaId)).thenReturn(true);
+        when(contactRepository.existsByAgendaId(agendaId)).thenReturn(false);
+        doNothing().when(agendaRepository).deleteById(agendaId);
+
+        agendaService.delete(agendaId);
+
+        verify(agendaRepository).existsById(agendaId);
+        verify(contactRepository).existsByAgendaId(agendaId);
+        verify(agendaRepository).deleteById(agendaId);
+    }
+
+    @Test
+    @DisplayName("delete should throw exception when agenda has associated contacts")
+    void delete_shouldThrowException_whenAgendaHasAssociatedContacts() {
+        var agendaId = UUID.randomUUID();
+        when(agendaRepository.existsById(agendaId)).thenReturn(true);
+        when(contactRepository.existsByAgendaId(agendaId)).thenReturn(true);
+
+        assertThatThrownBy(() -> agendaService.delete(agendaId))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Cannot delete agenda with associated contacts.");
+
+        verify(agendaRepository).existsById(agendaId);
+        verify(contactRepository).existsByAgendaId(agendaId);
+        verify(agendaRepository, never()).deleteById(any(UUID.class));
+    }
+
+}

--- a/src/test/java/br/com/personal/opencontact/api/contact/ContactControllerIT.java
+++ b/src/test/java/br/com/personal/opencontact/api/contact/ContactControllerIT.java
@@ -1,0 +1,94 @@
+package br.com.personal.opencontact.api.contact;
+
+import br.com.personal.opencontact.api.AbstractIntegrationTest;
+import br.com.personal.opencontact.api.agenda.Agenda;
+import br.com.personal.opencontact.api.agenda.AgendaRepository;
+import br.com.personal.opencontact.api.contact.dto.ContactCreateDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@Transactional
+class ContactControllerIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AgendaRepository agendaRepository;
+
+    @Autowired
+    private ContactRepository contactRepository;
+
+    private Agenda savedAgenda;
+
+    @BeforeEach
+    void setUp() {
+        // CORREÇÃO 1: Garante um estado 100% limpo antes de cada teste.
+        // A ordem é importante para respeitar as chaves estrangeiras.
+        contactRepository.deleteAll();
+        agendaRepository.deleteAll();
+
+        // Agora, cria a agenda de teste em um banco de dados limpo.
+        Agenda agenda = new Agenda("Trabalho");
+        savedAgenda = agendaRepository.save(agenda);
+    }
+
+    @Test
+    @DisplayName("POST /agendas/{agendaId}/contacts should create a contact and return 201 Created")
+    void postContact_whenValidInput_shouldReturn201AndCreateContact() throws Exception {
+        // Arrange
+        var createDTO = new ContactCreateDTO("Marco", ContactType.MOBILE, "11", "987654321");
+        String jsonPayload = objectMapper.writeValueAsString(createDTO);
+
+        // Act & Assert - HTTP Level
+        mockMvc.perform(post("/agendas/{agendaId}/contacts", savedAgenda.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Marco"));
+
+        // Assert - Database Level (Agora a asserção funcionará)
+        var contacts = contactRepository.findAll();
+        assertThat(contacts).hasSize(1);
+        Contact persistedContact = contacts.get(0);
+        assertThat(persistedContact.getName()).isEqualTo("Marco");
+        assertThat(persistedContact.getAgenda().getId()).isEqualTo(savedAgenda.getId());
+    }
+
+    @Test
+    @DisplayName("POST /agendas/{agendaId}/contacts should return 409 when phone already exists in agenda")
+    void postContact_whenPhoneExists_shouldReturn409Conflict() throws Exception {
+        // Arrange
+        Contact existingContact = new Contact("Contato Antigo", ContactType.FIXED_LINE, "11", "987654321", savedAgenda);
+        contactRepository.save(existingContact);
+
+        var createDTO = new ContactCreateDTO("Contato Novo", ContactType.MOBILE, "11", "987654321");
+        String jsonPayload = objectMapper.writeValueAsString(createDTO);
+
+        // Act & Assert
+        mockMvc.perform(post("/agendas/{agendaId}/contacts", savedAgenda.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonPayload))
+                // CORREÇÃO 2: Espera o status 409 Conflict.
+                .andExpect(status().isConflict());
+
+        // Garante que nenhum contato novo foi criado
+        assertThat(contactRepository.findAll()).hasSize(1);
+    }
+}

--- a/src/test/java/br/com/personal/opencontact/api/contact/ContactServiceTest.java
+++ b/src/test/java/br/com/personal/opencontact/api/contact/ContactServiceTest.java
@@ -1,0 +1,212 @@
+package br.com.personal.opencontact.api.contact;
+
+import br.com.personal.opencontact.api.agenda.Agenda;
+import br.com.personal.opencontact.api.agenda.AgendaRepository;
+import br.com.personal.opencontact.api.common.exceptions.PhoneAlreadyExistsException;
+import br.com.personal.opencontact.api.contact.dto.ContactCreateDTO;
+import br.com.personal.opencontact.api.contact.dto.ContactUpdateDTO;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ContactServiceTest {
+
+    @Mock
+    private ContactRepository contactRepository;
+
+    @Mock
+    private AgendaRepository agendaRepository;
+
+    @InjectMocks
+    private ContactService contactService;
+
+    @Test
+    @DisplayName("create should save contact when phone is unique and agenda exists")
+    void create_shouldSaveContact_whenSuccessful() {
+        // Arrange
+        var agendaId = UUID.randomUUID();
+        var createDTO = new ContactCreateDTO("John Doe", ContactType.MOBILE, "11", "987654321");
+        var agenda = new Agenda("Familia");
+        agenda.setId(agendaId);
+        var generatedId = UUID.randomUUID();
+
+        when(contactRepository.existsByAgendaIdAndAreaCodeAndPhoneNumber(agendaId, "11", "987654321")).thenReturn(false);
+        when(agendaRepository.findById(agendaId)).thenReturn(Optional.of(agenda));
+        when(contactRepository.save(any(Contact.class))).thenAnswer(invocation -> {
+            Contact contact = invocation.getArgument(0);
+            contact.setId(generatedId);
+            return contact;
+        });
+
+        // Act
+        Contact savedContact = contactService.create(agendaId, createDTO);
+
+        // Assert
+        assertThat(savedContact).isNotNull();
+        assertThat(savedContact.getId()).isEqualTo(generatedId);
+        assertThat(savedContact.getName()).isEqualTo("John Doe");
+        assertThat(savedContact.getAreaCode()).isEqualTo("11");
+        assertThat(savedContact.getPhoneNumber()).isEqualTo("987654321");
+        assertThat(savedContact.getAgenda().getId()).isEqualTo(agendaId);
+        verify(contactRepository).existsByAgendaIdAndAreaCodeAndPhoneNumber(agendaId, "11", "987654321");
+        verify(agendaRepository).findById(agendaId);
+        verify(contactRepository).save(any(Contact.class));
+    }
+
+    @Test
+    @DisplayName("create should throw exception when phone already exists in agenda")
+    void create_shouldThrowException_whenPhoneAlreadyExists() {
+        // Arrange
+        var agendaId = UUID.randomUUID();
+        var createDTO = new ContactCreateDTO("John Doe", ContactType.MOBILE, "11", "987654321");
+        when(contactRepository.existsByAgendaIdAndAreaCodeAndPhoneNumber(agendaId, "11", "987654321")).thenReturn(true);
+
+        // Act & Assert
+        assertThatThrownBy(() -> contactService.create(agendaId, createDTO))
+                .isInstanceOf(PhoneAlreadyExistsException.class)
+                .hasMessage("Phone number already registered in this agenda.");
+
+        verify(agendaRepository, never()).findById(any());
+        verify(contactRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("create should throw exception when agenda does not exist")
+    void create_shouldThrowException_whenAgendaNotFound() {
+        // Arrange
+        var agendaId = UUID.randomUUID();
+        var createDTO = new ContactCreateDTO("John Doe", ContactType.MOBILE, "11", "987654321");
+        when(contactRepository.existsByAgendaIdAndAreaCodeAndPhoneNumber(agendaId, "11", "987654321")).thenReturn(false);
+        when(agendaRepository.findById(agendaId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThatThrownBy(() -> contactService.create(agendaId, createDTO))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("Agenda not found with id: " + agendaId);
+
+        verify(contactRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("update should change contact details when successful")
+    void update_shouldChangeContactDetails_whenSuccessful() {
+        // Arrange
+        var agendaId = UUID.randomUUID();
+        var contactId = UUID.randomUUID();
+        var updateDTO = new ContactUpdateDTO("Jane Doe Updated", ContactType.FAX, "21", "23456789");
+
+        var agenda = new Agenda("Trabalho");
+        agenda.setId(agendaId);
+        var originalContact = new Contact("Jane Doe", ContactType.MOBILE, "11", "12345678", agenda);
+        originalContact.setId(contactId);
+
+        when(contactRepository.findById(contactId)).thenReturn(Optional.of(originalContact));
+        when(contactRepository.findByAgendaIdAndAreaCodeAndPhoneNumber(agendaId, "21", "23456789")).thenReturn(Optional.empty());
+        when(contactRepository.save(any(Contact.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Act
+        Contact updatedContact = contactService.update(contactId, updateDTO);
+
+        // Assert
+        assertThat(updatedContact).isNotNull();
+        assertThat(updatedContact.getId()).isEqualTo(contactId);
+        assertThat(updatedContact.getName()).isEqualTo("Jane Doe Updated");
+        assertThat(updatedContact.getAreaCode()).isEqualTo("21");
+        assertThat(updatedContact.getPhoneNumber()).isEqualTo("23456789");
+        verify(contactRepository).findById(contactId);
+        verify(contactRepository).findByAgendaIdAndAreaCodeAndPhoneNumber(agendaId, "21", "23456789");
+        verify(contactRepository).save(originalContact);
+    }
+
+    @Test
+    @DisplayName("update should throw exception when phone belongs to another contact")
+    void update_shouldThrowException_whenPhoneBelongsToAnotherContact() {
+        // Arrange
+        var agendaId = UUID.randomUUID();
+        var contactToUpdateId = UUID.randomUUID();
+        var otherContactId = UUID.randomUUID();
+        var updateDTO = new ContactUpdateDTO("Jane Doe Updated", ContactType.FAX, "11", "99998888");
+
+        var agenda = new Agenda("Trabalho");
+        agenda.setId(agendaId);
+        var contactToUpdate = new Contact("Jane Doe", ContactType.MOBILE, "11", "12345678", agenda);
+        contactToUpdate.setId(contactToUpdateId);
+
+        var otherContactWithPhone = new Contact("Other Guy", ContactType.MOBILE, "11", "99998888", agenda);
+        otherContactWithPhone.setId(otherContactId);
+
+        when(contactRepository.findById(contactToUpdateId)).thenReturn(Optional.of(contactToUpdate));
+        when(contactRepository.findByAgendaIdAndAreaCodeAndPhoneNumber(agendaId, "11", "99998888")).thenReturn(Optional.of(otherContactWithPhone));
+
+        // Act & Assert
+        assertThatThrownBy(() -> contactService.update(contactToUpdateId, updateDTO))
+                .isInstanceOf(PhoneAlreadyExistsException.class)
+                .hasMessage("Phone number already registered to another contact in this agenda.");
+
+        verify(contactRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("findById should return contact when id exists")
+    void findById_shouldReturnContact_whenIdExists() {
+        // Arrange
+        var contactId = UUID.randomUUID();
+        var contact = new Contact();
+        contact.setId(contactId);
+        contact.setName("Jane Doe");
+
+        when(contactRepository.findById(contactId)).thenReturn(Optional.of(contact));
+
+        // Act
+        Contact foundContact = contactService.findById(contactId);
+
+        // Assert
+        assertThat(foundContact).isNotNull();
+        assertThat(foundContact.getId()).isEqualTo(contactId);
+        verify(contactRepository).findById(contactId);
+    }
+
+    @Test
+    @DisplayName("delete should remove contact when id exists")
+    void delete_shouldRemoveContact_whenIdExists() {
+        // Arrange
+        var contactId = UUID.randomUUID();
+        when(contactRepository.existsById(contactId)).thenReturn(true);
+        doNothing().when(contactRepository).deleteById(contactId);
+
+        // Act
+        contactService.delete(contactId);
+
+        // Assert
+        verify(contactRepository).existsById(contactId);
+        verify(contactRepository).deleteById(contactId);
+    }
+
+    @Test
+    @DisplayName("delete should throw exception when id does not exist")
+    void delete_shouldThrowException_whenIdDoesNotExist() {
+        // Arrange
+        var contactId = UUID.randomUUID();
+        when(contactRepository.existsById(contactId)).thenReturn(false);
+
+        // Act & Assert
+        assertThatThrownBy(() -> contactService.delete(contactId))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("Contact not found with id: " + contactId);
+
+        verify(contactRepository, never()).deleteById(any(UUID.class));
+    }
+}


### PR DESCRIPTION
This PR introduces a new endpoint to delete contacts whose names match a given prefix.
Alongside, it consolidates several improvements merged since the last release:

* **chore:** Use real Maven `clean install` in CI workflow
* **docs:** Remove Portuguese comments in `docker-compose`
* **feat:** Add integration tests with Testcontainers
* **docs:** Update automated tests status in `README`
* **chore:** Upgrade GitHub Actions Java setup
* **feat:** Add unit tests (merged in #6)
* **feat:** Add delete by name prefix endpoint for contacts (this PR, merged in #8)

**Impact:**

* Improves CI reliability and consistency.
* Cleans up documentation and configuration files.
* Expands test coverage with unit and integration tests.
* Adds new deletion functionality for contact management.

